### PR TITLE
Fix MenuRepository aliasing

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -38,10 +38,10 @@ services:
     public: true
 
   Adeliom\SyliusHappyCMSPlugin\Repository\Menu\MenuRepositoryInterface:
-    alias: happy_cms_menu.menu_item.repository
+    alias: happy_cms_menu.menu.repository
 
   Adeliom\SyliusHappyCMSPlugin\Repository\Menu\MenuItemRepositoryInterface:
-    alias: happy_cms_menu.menu.repository
+    alias: happy_cms_menu.menu_item.repository
 
   Adeliom\SyliusHappyCMSPlugin\Repository\Page\PageRepositoryInterface:
     alias: happy_cms_page.page.repository

--- a/config/services/menu.yaml
+++ b/config/services/menu.yaml
@@ -1,6 +1,6 @@
 services:
     happy_cms_menu.menu.repository:
-        class: Adeliom\SyliusHappyCMSPlugin\Repository\Menu\MenuItemRepository
+        class: Adeliom\SyliusHappyCMSPlugin\Repository\Menu\MenuRepositoryInterface
         arguments:
             - '@doctrine.orm.entity_manager'
         calls:

--- a/config/services/menu.yaml
+++ b/config/services/menu.yaml
@@ -41,7 +41,6 @@ services:
         autowire: true
         arguments:
             - '@doctrine.orm.entity_manager'
-            - '@twig'
             - '@router'
         tags:
             - controller.service_arguments


### PR DESCRIPTION
Running the command: `symfony console lint:container`  is failing

Error:
<img width="3569" height="310" alt="image" src="https://github.com/user-attachments/assets/424f8e6b-977d-43b7-a0da-6e0e86f5a0be" />


It looks like the aliases were reversed between the menu_item repository and the menu repository.

The alias are probably not usefull in the services.yaml as they are already defined in `config/services/menu.yaml`

Cheers :v: 