### PR TITLE
Allow changing EntityManager in Media Library

### DIFF
--- a/config/media/services.xml
+++ b/config/media/services.xml
@@ -7,8 +7,13 @@
     <services>
         <defaults autowire="true" autoconfigure="true"/>
 
+        <service id="easy_media.entity_manager_provider" class="Adeliom\SyliusHappyCMSPlugin\Services\Doctrine\DefaultEntityManagerProvider" public="true">
+            <argument key="$em" type="service" id="doctrine.orm.entity_manager"/>
+        </service>
+
         <service id="happy.cms.media.controller" class="Adeliom\SyliusHappyCMSPlugin\Controller\Media\MediaController" public="true" autowire="true">
             <argument key="$manager" type="service" id="happy.cms.media.manager"/>
+            <argument key="$entityManagerProvider" type="service" id="easy_media.entity_manager_provider"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="Adeliom\SyliusHappyCMSPlugin\Controller\Media\MediaController" alias="happy.cms.media.controller" public="true"/>
@@ -34,7 +39,7 @@
         <service id="happy.cms.media.manager" class="Adeliom\SyliusHappyCMSPlugin\Services\Media\MediaManager" public="true" autowire="true">
             <argument key="$filesystem" type="service" id="happy.cms.media.storage"/>
             <argument key="$helper" type="service" id="happy.cms.media.helper"/>
-            <argument key="$em" type="service" id="doctrine.orm.entity_manager"/>
+            <argument key="$entityManagerProvider" type="service" id="easy_media.entity_manager_provider"/>
             <argument key="$parameters" type="service" id="parameter_bag"/>
             <argument key="$translator" type="service" id="translator"/>
             <argument key="$eventDispatcher" type="service" id="event_dispatcher"/>
@@ -45,7 +50,7 @@
 
         <service id="happy.cms.media.helper" class="Adeliom\SyliusHappyCMSPlugin\Services\Media\MediaHelper" public="true" autowire="true">
             <argument key="$parameters" type="service" id="parameter_bag"/>
-            <argument key="$em" type="service" id="doctrine.orm.entity_manager"/>
+            <argument key="$entityManagerProvider" type="service" id="easy_media.entity_manager_provider"/>
         </service>
         <service id="Adeliom\SyliusHappyCMSPlugin\Services\Media\MediaHelper" alias="happy.cms.media.helper" public="true"/>
 

--- a/src/Controller/Media/MediaController.php
+++ b/src/Controller/Media/MediaController.php
@@ -15,9 +15,9 @@ use Adeliom\SyliusHappyCMSPlugin\Controller\Media\Module\NewFolder;
 use Adeliom\SyliusHappyCMSPlugin\Controller\Media\Module\Rename;
 use Adeliom\SyliusHappyCMSPlugin\Controller\Media\Module\Upload;
 use Adeliom\SyliusHappyCMSPlugin\Controller\Media\Module\Utils;
+use Adeliom\SyliusHappyCMSPlugin\Services\Doctrine\EntityManagerProviderInterface;
 use Adeliom\SyliusHappyCMSPlugin\Services\Media\MediaHelper;
 use Adeliom\SyliusHappyCMSPlugin\Services\Media\MediaManager;
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -59,13 +59,10 @@ class MediaController extends AbstractController
 
     protected MediaManager $manager;
 
-    protected ManagerRegistry $managerRegistry;
-
-    public function __construct(MediaManager $manager, ManagerRegistry $managerRegistry, ParameterBagInterface $bag, EventDispatcherInterface $dispatcher, TranslatorInterface $translator)
+    public function __construct(MediaManager $manager, EntityManagerProviderInterface $entityManagerProvider, ParameterBagInterface $bag, EventDispatcherInterface $dispatcher, TranslatorInterface $translator)
     {
         $this->manager = $manager;
-        $this->managerRegistry = $managerRegistry;
-        $this->em = $this->managerRegistry->getManager();
+        $this->em = $entityManagerProvider->getEntityManager();
 
         if (is_string($bag->get('sylius_happy_cms.media.ignore_files'))) {
             $this->ignoreFiles = $bag->get('sylius_happy_cms.media.ignore_files');

--- a/src/Services/Doctrine/DefaultEntityManagerProvider.php
+++ b/src/Services/Doctrine/DefaultEntityManagerProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\SyliusHappyCMSPlugin\Services\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class DefaultEntityManagerProvider implements EntityManagerProviderInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {}
+
+    public function getEntityManager(): EntityManagerInterface
+    {
+        return $this->em;
+    }
+}

--- a/src/Services/Doctrine/EntityManagerProviderInterface.php
+++ b/src/Services/Doctrine/EntityManagerProviderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\SyliusHappyCMSPlugin\Services\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+interface EntityManagerProviderInterface
+{
+    public function getEntityManager(): EntityManagerInterface;
+}

--- a/src/Services/Media/MediaHelper.php
+++ b/src/Services/Media/MediaHelper.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Adeliom\SyliusHappyCMSPlugin\Services\Media;
 
 use Adeliom\SyliusHappyCMSPlugin\Entity\Media\FolderInterface;
-use Adeliom\SyliusHappyCMSPlugin\Entity\Media\Media;
 use Adeliom\SyliusHappyCMSPlugin\Entity\Media\MediaInterface;
 use Adeliom\SyliusHappyCMSPlugin\Repository\Media\MediaRepositoryInterface;
+use Adeliom\SyliusHappyCMSPlugin\Services\Doctrine\EntityManagerProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Psr\Container\ContainerExceptionInterface;
@@ -19,9 +19,14 @@ class MediaHelper
 {
     public function __construct(
         protected ContainerBagInterface $parameters,
-        protected EntityManagerInterface $em,
+        protected EntityManagerProviderInterface $entityManagerProvider,
         protected RouterInterface $router,
     ) {
+    }
+
+    public function getEntityManager(): EntityManagerInterface
+    {
+        return $this->entityManagerProvider->getEntityManager();
     }
 
     public function getFolderClassName(): string
@@ -39,7 +44,7 @@ class MediaHelper
     {
         $class = $this->getFolderClassName();
         if (class_exists($class) && in_array(FolderInterface::class, class_implements($class))) {
-            return $this->em->getRepository($class);
+            return $this->getEntityManager()->getRepository($class);
         }
 
         return null;
@@ -57,7 +62,7 @@ class MediaHelper
     {
         $class = $this->getMediaClassName();
         if (class_exists($class) && in_array(MediaInterface::class, class_implements($class))) {
-            $repo = $this->em->getRepository($class);
+            $repo = $this->getEntityManager()->getRepository($class);
 
             return $repo instanceof MediaRepositoryInterface ? $repo : null;
         }

--- a/src/Services/Media/MediaManager.php
+++ b/src/Services/Media/MediaManager.php
@@ -14,6 +14,7 @@ use Adeliom\SyliusHappyCMSPlugin\Exceptions\Media\FolderAlreadyExist;
 use Adeliom\SyliusHappyCMSPlugin\Exceptions\Media\FolderNotExist;
 use Adeliom\SyliusHappyCMSPlugin\Exceptions\Media\NoFile;
 use Adeliom\SyliusHappyCMSPlugin\Exceptions\Media\ProviderNotFound;
+use Adeliom\SyliusHappyCMSPlugin\Services\Doctrine\EntityManagerProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Embed\Embed;
 use Illuminate\Support\Str;
@@ -33,7 +34,7 @@ class MediaManager
     public function __construct(
         protected FilesystemOperator $filesystem,
         protected MediaHelper $helper,
-        public EntityManagerInterface $em,
+        protected EntityManagerProviderInterface $entityManagerProvider,
         protected ContainerBagInterface $parameters,
         protected TranslatorInterface $translator,
         protected EventDispatcherInterface $eventDispatcher,
@@ -50,6 +51,11 @@ class MediaManager
     public function getHelper(): MediaHelper
     {
         return $this->helper;
+    }
+
+    public function getEntityManager(): EntityManagerInterface
+    {
+        return $this->entityManagerProvider->getEntityManager();
     }
 
     public function getPath(MediaInterface $media): ?string
@@ -249,7 +255,7 @@ class MediaManager
      */
     public function delete(MediaInterface|FolderInterface $item, ?bool $flush = true): void
     {
-        $this->em->remove($item);
+        $this->getEntityManager()->remove($item);
 
         if ($item instanceof FolderInterface) {
             $this->filesystem->deleteDirectory($item->getPath());
@@ -260,15 +266,15 @@ class MediaManager
         }
 
         if ($flush) {
-            $this->em->flush();
+            $this->getEntityManager()->flush();
         }
     }
 
     public function save(MediaInterface|FolderInterface $item, ?bool $flush = true): void
     {
-        $this->em->persist($item);
+        $this->getEntityManager()->persist($item);
         if ($flush) {
-            $this->em->flush();
+            $this->getEntityManager()->flush();
         }
     }
 


### PR DESCRIPTION
This way we can connect different database defined in the doctrine configuration,
not just the default one. Because sometimes the media database may be in a different
place than the app's one