### PR TITLE
feat: compatibilité easy-crud 2.1 (#[AsAdmin]) — génération dual-mode YAML/attributs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-exif": "*",
         "ext-intl": "*",
         "ext-json": "*",
-        "agence-adeliom/sylius-easy-crud-plugin": "^v2.0.4",
+        "agence-adeliom/sylius-easy-crud-plugin": "^2.1",
         "emileperron/tinymce-bundle": "^3.0",
         "illuminate/support": "^v11.33.2",
         "james-heinrich/getid3": "^1.9",

--- a/docs/skills/happy-cms-migrate-to-attributes/SKILL.md
+++ b/docs/skills/happy-cms-migrate-to-attributes/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: happy-cms-migrate-to-attributes
+description: Migrate HappyCMS admin resources (page, shared_block, menu, config, route, redirect_route, menu_item) from legacy YAML declaration (config/routes.yaml `type: sylius.resource` + config/packages/sylius_resource.yaml) to the `#[AsAdmin]` attribute on Admin classes. Use when upgrading easy-crud to 2.1+ and see deprecations about "Declaring the easy-crud resource ... through legacy YAML" for HappyCMS resources.
+---
+
+# Migrate HappyCMS resources to `#[AsAdmin]` attributes
+
+Since easy-crud 2.1, HappyCMS admin resources are declared with **one attribute** instead of two legacy YAML blocks:
+
+- **`#[Adeliom\SyliusEasyCrudPlugin\Metadata\AsAdmin]` on the Admin class** — the easy-crud layer with admin UI/routing metadata.
+
+Unlike generic easy-crud resources, HappyCMS does **not** require `#[\Sylius\Resource\Metadata\AsResource]` on the entity because the entity class and alias are already defined via the `getName()` and `getEntityFqcn()` methods on the Admin class (which you will preserve).
+
+This skill performs that migration safely, one resource at a time.
+
+## Golden rules
+
+- **Preserve `alias` + `section`.** Route names and URLs are derived only from these. Keep them identical or you break links, redirects and templates. The alias is embedded in the attribute.
+- **Preserve the grid name.** It is `Admin::getName()`; the grid is registered under it. **Do not** capture it into the attribute unless it differs from the auto-derived name (see Step 3). Keep the method.
+- **Keep `getName()` and `getEntityFqcn()`.** They are still called by easy-crud; do not remove them.
+- **One resource at a time, then verify.** The legacy and attribute systems coexist, so migrate, run the verification, then move on.
+- **Never invent values.** Only move what already exists in the YAML / Admin into the attributes.
+- **Media and media_folder stay in YAML.** These have no Admin class, so skip them entirely.
+
+## Prerequisites
+
+1. `agence-adeliom/sylius-easy-crud-plugin` is `>= 2.1`.
+2. Enable discovery **once for the project** — single path list in the app:
+
+   ```yaml
+   # config/packages/sylius_easy_crud.yaml
+   sylius_easy_crud:
+       attributes:
+           enabled: true
+           paths: ['%kernel.project_dir%/src/Admin/HappyCMS']
+   ```
+
+   This tells easy-crud where to scan for `#[AsAdmin]` classes. If you scaffolded Admin classes in a different namespace (e.g. `App\Admin\HappyCMS\*`), list that path instead.
+
+3. Do **not** add `sylius_resource.mapping.paths` — it is already handled by the plugin bundle at `Adeliom\SyliusHappyCMSPlugin\Entity`.
+
+## Migration table
+
+Each HappyCMS resource has a fixed Admin class and configuration. Use this table to apply the correct `#[AsAdmin]` arguments:
+
+| Resource | Alias | Admin Class (in plugin) | Entity | Controller | Translatable | Special notes |
+|----------|-------|------------------------|--------|-----------|--------------|--------------|
+| **page** | `sylius_happy_cms.page` | `Adeliom\SyliusHappyCMSPlugin\Admin\Page\PageAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\Page\PageInterface` | `Adeliom\SyliusHappyCMSPlugin\Controller\Page\PageResourceController` | Yes | Custom templates + page builder context |
+| **shared_block** | `sylius_happy_cms.shared_block` | `Adeliom\SyliusHappyCMSPlugin\Admin\SharedBlock\SharedBlockAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\SharedBlock\SharedBlock` | Default (SyliusCrudResourceController) | Yes | Standard crud |
+| **config** | `sylius_happy_cms.config` | `Adeliom\SyliusHappyCMSPlugin\Admin\Config\ConfigAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\Config\Config` | Default | Yes | Standard crud |
+| **menu** | `sylius_happy_cms.menu` | `Adeliom\SyliusHappyCMSPlugin\Admin\Menu\MenuAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\Menu\Menu` | Default | No | Standard crud |
+| **menu_item** | `sylius_happy_cms.menu_item` | `Adeliom\SyliusHappyCMSPlugin\Admin\Menu\MenuItemAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\Menu\MenuItem` | Default | Yes | `except: ['index']` + custom templates |
+| **route** | `sylius_happy_cms.route` | `Adeliom\SyliusHappyCMSPlugin\Admin\Cmf\RouteAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\Cmf\RouteInterface` | Default | No | Standard crud |
+| **redirect_route** | `sylius_happy_cms.redirect_route` | `Adeliom\SyliusHappyCMSPlugin\Admin\Cmf\RedirectRouteAdmin` | `Adeliom\SyliusHappyCMSPlugin\Entity\Cmf\RedirectRoute` | Default | No | Standard crud |
+| media | — | — | — | — | — | **Stay in YAML** (no admin) |
+| media_folder | — | — | — | — | — | **Stay in YAML** (no admin) |
+
+## Step 1 — Enable discovery
+
+Edit `config/packages/sylius_easy_crud.yaml`:
+
+```yaml
+sylius_easy_crud:
+    attributes:
+        enabled: true
+        paths: ['%kernel.project_dir%/src/Admin/HappyCMS']
+```
+
+This is a one-time setup for the entire project.
+
+## Step 2 — Pick a HappyCMS resource
+
+Choose one from the table above (not `media` or `media_folder`) and locate:
+- Its Admin class in the plugin: `Adeliom\SyliusHappyCMSPlugin\Admin\*\*Admin.php`
+- Its two YAML declarations in `tests/TestApplication/config/`:
+  - `config/packages/sylius_resource.yaml` — the `sylius_resource.resources.<alias>` block.
+  - `config/routes.yaml` — the `sylius_happy_cms_*_admin` route block (with `type: sylius.resource`).
+
+Example for `shared_block`:
+```bash
+grep -n "sylius_happy_cms.shared_block" tests/TestApplication/config/packages/sylius_resource.yaml tests/TestApplication/config/routes.yaml
+```
+
+## Step 3 — Build the `#[AsAdmin]` attribute
+
+Map the route block (`config/routes.yaml`) to the attribute using this table. **Omit any argument that equals the default.**
+
+| YAML field | Argument | Default | Notes |
+|-----------|----------|---------|-------|
+| `alias` | `alias:` | `'sylius_happy_cms.<resource>'` | Always set (from the table). |
+| `section` | `section:` | `'admin'` | Omit unless you override. |
+| `prefix` (import level) | `prefix:` | `'admin'` | Omit unless you override. |
+| `redirect` | `redirect:` | `'update'` | Omit unless you override. |
+| `grid` (= `Admin::getName()`) | `grid:` | auto-derived from alias | **Usually omitted** — easy-crud will derive it as `sylius_happy_cms_<resource>_admin`. Check if the YAML `grid:` equals this; if yes, omit it. |
+| `form.type` (the Admin) | (implicit, don't set) | — | The Admin class is discovered by path scan; no argument needed. |
+| `templates` | `templates:` | `'@SyliusEasyCrudPlugin\crud'` | Set if you use a custom template dir (e.g., `page` uses `@SyliusHappyCMSPlugin\page\crud`). |
+| `except` / `only` | `except:` / `only:` | `[]` | Set only for `menu_item` (`except: ['index']`). |
+| `vars.all.icon` | `icon:` | `'file'` | Omit (icon is `file` for all). |
+| `vars.all.subheader` | `subheader:` | auto-derived i18n key | Almost always omit — easy-crud derives it as `'sylius_happy_cms.<resource>.admin.ui.subheader'`. |
+| `vars.all.breadcrumb` | `breadcrumb:` | auto-derived i18n key | Almost always omit — easy-crud derives it as `'sylius_happy_cms.<resource>.admin.ui.index'`. |
+| `vars.*.header` (per action) | `header:` or per-action in `vars:` | auto-derived i18n keys | Omit — easy-crud auto-derives them. |
+| `classes.controller` (if not default) | `controller:` | `SyliusCrudResourceController` | Set only for `page` (`Adeliom\SyliusHappyCMSPlugin\Controller\Page\PageResourceController`). |
+| any custom `vars` (action-specific overrides) | `vars:` (free-form) | `[]` | Only if YAML has custom keys beyond standard headers/redirects. |
+
+**Golden rule**: If the YAML already uses auto-derivable i18n keys and templates, **omit them from the attribute** — easy-crud will regenerate them.
+
+### Examples
+
+#### shared_block (simplest)
+YAML declares default routing and standard headers. The attribute is minimal:
+
+```php
+#[AsAdmin(
+    alias: 'sylius_happy_cms.shared_block',
+)]
+class SharedBlockAdmin extends AbstractSharedBlockAdmin implements ...
+{
+    public static function getName(): string { return 'sylius_happy_cms_shared_block_admin'; }
+    public static function getEntityFqcn(): string { return SharedBlock::class; }
+}
+```
+
+#### page (custom controller + templates)
+YAML specifies a custom controller and custom template directory. The attribute includes both:
+
+```php
+#[AsAdmin(
+    alias: 'sylius_happy_cms.page',
+    controller: 'Adeliom\SyliusHappyCMSPlugin\Controller\Page\PageResourceController::class',
+    templates: '@SyliusHappyCMSPlugin\page\crud',
+)]
+class PageAdmin extends AbstractPageAdmin
+{
+    public static function getName(): string { return 'sylius_happy_cms_page_admin'; }
+    public static function getEntityFqcn(): string { return PageInterface::class; }
+}
+```
+
+#### menu_item (except + custom vars)
+YAML excludes the `index` action and uses custom breadcrumb templates. The attribute includes both:
+
+```php
+#[AsAdmin(
+    alias: 'sylius_happy_cms.menu_item',
+    except: ['index'],
+    vars: [
+        'update' => [
+            'templates' => [
+                'breadcrumb' => '@SyliusHappyCMSPlugin\menu_item\crud\_breadcrumb.html.twig',
+            ],
+        ],
+    ],
+)]
+class MenuItemAdmin extends AbstractMenuItemAdmin implements MenuItemAdminInterface
+{
+    public static function getName(): string { return 'sylius_happy_cms_menu_item_admin'; }
+    public static function getEntityFqcn(): string { return MenuItem::class; }
+}
+```
+
+## Step 4 — Apply the attribute to the Admin class
+
+The plugin Admin classes (in `Adeliom\SyliusHappyCMSPlugin\Admin\*`) are already written. **Do not edit them directly.** Instead, create an **app-level override** in your application's `src/Admin/HappyCMS/` directory:
+
+### Example: Create `src/Admin/HappyCMS/SharedBlock/SharedBlockAdmin.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\HappyCMS\SharedBlock;
+
+use Adeliom\SyliusHappyCMSPlugin\Entity\SharedBlock\SharedBlock;
+use Adeliom\SyliusEasyCrudPlugin\Metadata\AsAdmin;
+use Adeliom\SyliusHappyCMSPlugin\Admin\SharedBlock\AbstractSharedBlockAdmin;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+#[AsAdmin(
+    alias: 'sylius_happy_cms.shared_block',
+)]
+class SharedBlockAdmin extends AbstractSharedBlockAdmin implements ServiceSubscriberInterface
+{
+    public static function getSubscribedServices(): array
+    {
+        return [];
+    }
+
+    public static function getName(): string
+    {
+        return 'sylius_happy_cms_shared_block_admin';
+    }
+
+    public static function getEntityFqcn(): string
+    {
+        return SharedBlock::class;
+    }
+}
+```
+
+**Key points:**
+- Place it in `src/Admin/HappyCMS/<ResourceName>/` (mirrors the plugin structure).
+- Extend the **abstract base** class from the plugin (e.g., `AbstractSharedBlockAdmin`).
+- **Do not remove** `getSubscribedServices()`, `getName()`, or `getEntityFqcn()`.
+- Add the `#[AsAdmin(...)]` attribute above the class.
+- If the class implements `ServiceSubscriberInterface` **and** `getSubscribedServices()` returns `[]`, you may optionally remove both; otherwise keep them.
+
+### Service configuration (optional)
+
+If your app does not auto-register Admin classes, add them to `config/services.yaml`:
+
+```yaml
+App\Admin\HappyCMS\:
+    resource: '%kernel.project_dir%/src/Admin/HappyCMS'
+    public: false
+```
+
+Most modern Symfony apps auto-register by default; check if it's already there.
+
+## Step 5 — Remove the legacy YAML blocks
+
+Once the `#[AsAdmin]` is in place on the app-level Admin class, delete:
+
+1. **The route block** in `config/routes.yaml` — the entire `sylius_happy_cms_<resource>_admin` entry with `type: sylius.resource`.
+2. **The resource block** in `config/packages/sylius_resource.yaml` — the entire `sylius_resource.resources.sylius_happy_cms.<resource>` entry (including its `translation:` sub-block).
+
+**Leave media and media_folder YAML untouched.**
+
+Example: to remove `shared_block`, delete these two blocks (from tests/TestApplication/config/):
+
+```yaml
+# config/packages/sylius_resource.yaml - DELETE:
+sylius_happy_cms.shared_block:
+    driver: doctrine/orm
+    classes:
+        model: Tests\...
+        controller: Adeliom\...
+        repository: Tests\...
+        form: Tests\...
+    translation:
+        # ...
+
+# config/routes.yaml - DELETE:
+sylius_happy_cms_shared_block_admin:
+    resource: |
+        alias: sylius_happy_cms.shared_block
+        # ...
+    type: sylius.resource
+    prefix: admin
+```
+
+## Step 6 — Verify
+
+```bash
+# 1. If using DDEV, prefix commands with `ddev`:
+# ddev bin/console ...
+
+# 2. Clear cache:
+bin/console cache:clear
+
+# 3. Check that routes are unchanged:
+bin/console debug:router | grep sylius_happy_cms.<resource> | sort
+
+# 4. Confirm the controller is the easy-crud one (not the default):
+bin/console debug:container sylius_happy_cms.<resource>.controller
+
+# 5. Ensure no more deprecations for this resource:
+bin/console debug:container --deprecations | grep sylius_happy_cms.<resource>
+```
+
+Open the admin screens (index, create, edit, delete) in the browser to confirm the grid, form and redirects still work.
+
+## Step 7 — Repeat
+
+Go back to Step 2 for the next HappyCMS resource until all are migrated. Final check:
+
+```bash
+bin/console debug:container --deprecations | grep sylius_happy_cms   # should be empty
+```
+
+If the result is empty, all HappyCMS resources are migrated.
+
+---
+
+## Troubleshooting
+
+### Double-declaration error (routes conflict)
+
+**Symptom**: "Cannot redeclare route name `sylius_happy_cms.shared_block.index`."
+
+**Cause**: You added the `#[AsAdmin]` but did not remove the legacy YAML blocks. Both systems are trying to declare the same routes.
+
+**Fix**: Delete the `sylius_happy_cms_<resource>_admin` entry from `config/routes.yaml` and the `sylius_resource.resources.sylius_happy_cms.<resource>` block from `config/packages/sylius_resource.yaml`.
+
+### Admin class not discovered
+
+**Symptom**: Routes still fail after adding the attribute; deprecation still reports "legacy YAML."
+
+**Cause**: The app-level Admin class is not in a scanned path.
+
+**Fix**: 
+1. Ensure `config/packages/sylius_easy_crud.yaml` lists your Admin directory:
+   ```yaml
+   sylius_easy_crud:
+       attributes:
+           paths: ['%kernel.project_dir%/src/Admin/HappyCMS']
+   ```
+2. Run `bin/console cache:clear`.
+3. If using DDEV, ensure you are running inside the container (`ddev bin/console ...`).
+
+### i18n keys not translating
+
+**Symptom**: Admin headers show `sylius_happy_cms.shared_block.admin.ui.index` as plain text instead of the translation.
+
+**Cause**: The resource's translation files are missing from the app.
+
+**Fix**: Ensure your app has the locale i18n files in `translations/` (they are usually inherited from the plugin). If not, copy them from the plugin's `src/Resources/translations/`.
+
+---
+
+## Summary
+
+To migrate a HappyCMS resource:
+
+1. **Enable discovery** (once): set `sylius_easy_crud.attributes.paths` in `config/packages/sylius_easy_crud.yaml`.
+2. **Create app-level Admin** in `src/Admin/HappyCMS/<ResourceName>/` extending the plugin's abstract.
+3. **Add `#[AsAdmin]`** with the resource's alias (from the migration table).
+4. **Delete the two YAML blocks** (route + resource) for that resource.
+5. **Run `bin/console cache:clear` and verify** routes are unchanged; open the admin screen.
+6. **Repeat** for the next resource.
+
+When all are done, `bin/console debug:container --deprecations | grep sylius_happy_cms` should return nothing.

--- a/src/Maker/CMS/MakeHappyCMS.php
+++ b/src/Maker/CMS/MakeHappyCMS.php
@@ -12,6 +12,7 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -353,11 +354,7 @@ final class MakeHappyCMS extends AbstractMaker
                 'hasRouting' => $hasRouting,
             ];
 
-            if ($this->attributesModeEnabled()) {
-                $adminVariables['asAdminAttribute'] = $this->buildAsAdminAttribute(ucfirst($scope));
-            }
-
-            $resourceConfigGenerator->generateAdmin(
+            $entryAdminDetails = $resourceConfigGenerator->generateAdmin(
                 className: $entryClassNameDetail->getFullName(),
                 templatePath: self::TPL_FILES['admin'],
                 variables: $adminVariables,
@@ -372,18 +369,14 @@ final class MakeHappyCMS extends AbstractMaker
                     'hasRouting' => $hasRouting,
                 ];
 
-                if ($this->attributesModeEnabled()) {
-                    $taxonomyVariables['asAdminAttribute'] = $this->buildAsAdminAttribute(ucfirst($scope));
-                }
-
-                $resourceConfigGenerator->generateAdmin(
+                $taxonomyAdminDetails = $resourceConfigGenerator->generateAdmin(
                     className:    $taxonomyClassNameDetail->getFullName(),
                     templatePath: self::TPL_FILES['admin'],
                     variables:    $taxonomyVariables,
                 );
             }
 
-            $resourceConfigGenerator->generateController(
+            $controllerDetails = $resourceConfigGenerator->generateController(
                 className: $entryClassNameDetail->getFullName(),
                 templatePath: self::TPL_FILES['controller'],
                 variables: [
@@ -432,7 +425,29 @@ final class MakeHappyCMS extends AbstractMaker
 
                 $io->note('Please copy the above configuration into the \'config/packages/sylius_resources.yaml\' file');
             } else {
-                $io->note('Resource configuration will be auto-discovered via #[AsAdmin] attributes on the Admin classes.');
+                // Attribute mode: declare via #[AsResource] (entity) + #[AsAdmin] (admin), reusing
+                // easy-crud's own generator so the result matches the legacy YAML blocks it replaces
+                // (same alias/grid/controller). The entry resource carries its custom controller;
+                // the taxonomy resource uses the default easy-crud controller.
+                $this->declareViaAttributes(
+                    $resourceConfigGenerator,
+                    $entryClassNameDetail,
+                    $entryAdminDetails,
+                    $controllerDetails->getFullName(),
+                    $io,
+                );
+
+                if ($hasTaxonomy && $taxonomyClassNameDetail && isset($taxonomyAdminDetails)) {
+                    $this->declareViaAttributes(
+                        $resourceConfigGenerator,
+                        $taxonomyClassNameDetail,
+                        $taxonomyAdminDetails,
+                        null,
+                        $io,
+                    );
+                }
+
+                $io->note('Resources declared via #[AsResource] + #[AsAdmin] attributes (auto-discovered).');
             }
         } catch (\Exception $exception) {
             $io->error($exception->getMessage());
@@ -454,28 +469,38 @@ final class MakeHappyCMS extends AbstractMaker
     }
 
     /**
-     * Build the AsAdmin attribute source code for a CMS model scope.
+     * Declare a generated CMS resource via attributes — #[AsResource] on the entity and
+     * #[AsAdmin] on the Admin — by delegating to easy-crud's CrudMakerService. Reusing
+     * easy-crud's own generator guarantees the alias/grid/controller match the legacy YAML
+     * blocks this replaces (so toggling sylius_easy_crud.attributes.enabled keeps routes stable).
      */
-    private function buildAsAdminAttribute(string $scope): string
-    {
-        $aliasScope = mb_strtolower(Str::asSnakeCase(Str::singularCamelCaseToPluralCamelCase($scope)));
+    private function declareViaAttributes(
+        CrudMakerService $generator,
+        ClassNameDetails $entity,
+        ClassNameDetails $admin,
+        ?string $controller,
+        ConsoleStyle $io,
+    ): void {
+        $entityPath = $generator->getGeneratedClassPath($entity->getFullName());
+        if (null !== $entityPath) {
+            $generator->addAsResourceAttributeToEntity($entityPath, $entity->getShortName());
+            $io->comment(sprintf('%s: %s (#[AsResource])', '<fg=yellow>updated</>', $entityPath));
+        }
 
-        $lines = ['#[AsAdmin('];
-        $lines[] = "    alias: 'happy_cms_admin_{$aliasScope}',";
-        $lines[] = "    subheader: 'happy_cms.{$scope}.admin.ui.subheader',";
-        $lines[] = "    breadcrumb: 'happy_cms.{$scope}.admin.ui.index',";
-        $lines[] = '    vars: [';
-        $lines[] = "        'index' => ['header' => 'happy_cms.{$scope}.admin.ui.index'],";
-        $lines[] = "        'create' => ['header' => 'happy_cms.{$scope}.admin.ui.create'],";
-        $lines[] = "        'update' => ['header' => 'happy_cms.{$scope}.admin.ui.update'],";
-        $lines[] = "        'show' => [";
-        $lines[] = "            'header' => 'happy_cms.{$scope}.admin.ui.show',";
-        $lines[] = "            'redirect' => ['route' => 'update', 'parameters' => ['context' => '\$context', 'id' => '\$id']],";
-        $lines[] = "            'route' => ['parameters' => ['context' => '\$context', 'id' => '\$id']],";
-        $lines[] = '        ],';
-        $lines[] = '    ],';
-        $lines[] = ')]';
+        $adminPath = $generator->getGeneratedClassPath($admin->getFullName());
+        if (null === $adminPath) {
+            return;
+        }
 
-        return implode("\n", $lines);
+        $customController = (null !== $controller && class_exists($controller)) ? $controller : null;
+
+        $generator->addEasyCrudAttributeToClass(
+            $adminPath,
+            $admin->getShortName(),
+            $customController,
+            Str::asClassName($entity->getShortName()),
+            'admin_' . mb_strtolower(Str::asSnakeCase($entity->getShortName())),
+        );
+        $io->comment(sprintf('%s: %s (#[AsAdmin])', '<fg=yellow>updated</>', $adminPath));
     }
 }

--- a/src/Maker/CMS/MakeHappyCMS.php
+++ b/src/Maker/CMS/MakeHappyCMS.php
@@ -345,29 +345,41 @@ final class MakeHappyCMS extends AbstractMaker
                 );
             }
 
+            $adminVariables = [
+                'classNameDetail' => $entryClassNameDetail,
+                'relationClassNameDetail' => $taxonomyClassNameDetail,
+                'scope' => ucfirst($scope),
+                'hasFlexibleContent' => $hasFlexibleContent,
+                'hasRouting' => $hasRouting,
+            ];
+
+            if ($this->attributesModeEnabled()) {
+                $adminVariables['asAdminAttribute'] = $this->buildAsAdminAttribute(ucfirst($scope));
+            }
+
             $resourceConfigGenerator->generateAdmin(
                 className: $entryClassNameDetail->getFullName(),
                 templatePath: self::TPL_FILES['admin'],
-                variables: [
-                    'classNameDetail' => $entryClassNameDetail,
-                    'relationClassNameDetail' => $taxonomyClassNameDetail,
-                    'scope' => ucfirst($scope),
-                    'hasFlexibleContent' => $hasFlexibleContent,
-                    'hasRouting' => $hasRouting,
-                ],
+                variables: $adminVariables,
             );
 
             if ($hasTaxonomy && $taxonomyClassNameDetail) {
+                $taxonomyVariables = [
+                    'classNameDetail' => $taxonomyClassNameDetail,
+                    'relationClassNameDetail' => $entryClassNameDetail,
+                    'scope' => ucfirst($scope),
+                    'hasFlexibleContent' => $hasFlexibleContent,
+                    'hasRouting' => $hasRouting,
+                ];
+
+                if ($this->attributesModeEnabled()) {
+                    $taxonomyVariables['asAdminAttribute'] = $this->buildAsAdminAttribute(ucfirst($scope));
+                }
+
                 $resourceConfigGenerator->generateAdmin(
                     className:    $taxonomyClassNameDetail->getFullName(),
                     templatePath: self::TPL_FILES['admin'],
-                    variables:    [
-                                      'classNameDetail' => $taxonomyClassNameDetail,
-                                      'relationClassNameDetail' => $entryClassNameDetail,
-                                      'scope' => ucfirst($scope),
-                                      'hasFlexibleContent' => $hasFlexibleContent,
-                                      'hasRouting' => $hasRouting,
-                                  ],
+                    variables:    $taxonomyVariables,
                 );
             }
 
@@ -382,42 +394,46 @@ final class MakeHappyCMS extends AbstractMaker
 
             $resourceConfigGenerator->generateMenuListener($entryClassNameDetail->getFullName());
 
-            $io->confirm(
-                'Press any key to continue and see the configuration to copy into the \'routes.yaml\' file',
-                true,
-            );
-            $config = $resourceConfigGenerator->generateRoute(true, $entryClassNameDetail->getFullName());
-            $io->text($config);
-            if ($hasTaxonomy && $taxonomyClassNameDetail) {
-                $configTaxonomy = $resourceConfigGenerator->generateRoute(true, $taxonomyClassNameDetail->getFullName());
-                $io->newLine();
-                $io->text($configTaxonomy);
-            }
-            $io->note('Please copy the above configuration into the \'config/routes.yaml\' file');
-            $io->note("Don't forget to add the new route _index into the Sylius administration menu");
-
-            $io->confirm(
-                'Press any key to continue and see the configuration to copy into the \'packages/sylius_resources.yaml\' file',
-                true,
-            );
-            $config = $resourceConfigGenerator->generateResource(
-                true,
-                $entryClassNameDetail->getFullName(),
-                $entryClassNameTranslationDetail->getFullName(),
-            );
-            $io->text($config);
-
-            if ($hasTaxonomy && $taxonomyClassNameDetail && $taxonomyClassNameTranslationDetail) {
-                $configTaxonomy = $resourceConfigGenerator->generateResource(
+            if (!$this->attributesModeEnabled()) {
+                $io->confirm(
+                    'Press any key to continue and see the configuration to copy into the \'routes.yaml\' file',
                     true,
-                    $taxonomyClassNameDetail->getFullName(),
-                    $taxonomyClassNameTranslationDetail->getFullName(),
                 );
-                $io->newLine();
-                $io->text(str_replace(['sylius_resource:', 'resources:'], ['', ''], $configTaxonomy));
-            }
+                $config = $resourceConfigGenerator->generateRoute(true, $entryClassNameDetail->getFullName());
+                $io->text($config);
+                if ($hasTaxonomy && $taxonomyClassNameDetail) {
+                    $configTaxonomy = $resourceConfigGenerator->generateRoute(true, $taxonomyClassNameDetail->getFullName());
+                    $io->newLine();
+                    $io->text($configTaxonomy);
+                }
+                $io->note('Please copy the above configuration into the \'config/routes.yaml\' file');
+                $io->note("Don't forget to add the new route _index into the Sylius administration menu");
 
-            $io->note('Please copy the above configuration into the \'config/packages/sylius_resources.yaml\' file');
+                $io->confirm(
+                    'Press any key to continue and see the configuration to copy into the \'packages/sylius_resources.yaml\' file',
+                    true,
+                );
+                $config = $resourceConfigGenerator->generateResource(
+                    true,
+                    $entryClassNameDetail->getFullName(),
+                    $entryClassNameTranslationDetail->getFullName(),
+                );
+                $io->text($config);
+
+                if ($hasTaxonomy && $taxonomyClassNameDetail && $taxonomyClassNameTranslationDetail) {
+                    $configTaxonomy = $resourceConfigGenerator->generateResource(
+                        true,
+                        $taxonomyClassNameDetail->getFullName(),
+                        $taxonomyClassNameTranslationDetail->getFullName(),
+                    );
+                    $io->newLine();
+                    $io->text(str_replace(['sylius_resource:', 'resources:'], ['', ''], $configTaxonomy));
+                }
+
+                $io->note('Please copy the above configuration into the \'config/packages/sylius_resources.yaml\' file');
+            } else {
+                $io->note('Resource configuration will be auto-discovered via #[AsAdmin] attributes on the Admin classes.');
+            }
         } catch (\Exception $exception) {
             $io->error($exception->getMessage());
         }
@@ -429,5 +445,37 @@ final class MakeHappyCMS extends AbstractMaker
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
         // No dependencies needed
+    }
+
+    private function attributesModeEnabled(): bool
+    {
+        return $this->parameterBag->has('sylius_easy_crud.attributes.enabled') &&
+            true === $this->parameterBag->get('sylius_easy_crud.attributes.enabled');
+    }
+
+    /**
+     * Build the AsAdmin attribute source code for a CMS model scope.
+     */
+    private function buildAsAdminAttribute(string $scope): string
+    {
+        $aliasScope = mb_strtolower(Str::asSnakeCase(Str::singularCamelCaseToPluralCamelCase($scope)));
+
+        $lines = ['#[AsAdmin('];
+        $lines[] = "    alias: 'happy_cms_admin_{$aliasScope}',";
+        $lines[] = "    subheader: 'happy_cms.{$scope}.admin.ui.subheader',";
+        $lines[] = "    breadcrumb: 'happy_cms.{$scope}.admin.ui.index',";
+        $lines[] = '    vars: [';
+        $lines[] = "        'index' => ['header' => 'happy_cms.{$scope}.admin.ui.index'],";
+        $lines[] = "        'create' => ['header' => 'happy_cms.{$scope}.admin.ui.create'],";
+        $lines[] = "        'update' => ['header' => 'happy_cms.{$scope}.admin.ui.update'],";
+        $lines[] = "        'show' => [";
+        $lines[] = "            'header' => 'happy_cms.{$scope}.admin.ui.show',";
+        $lines[] = "            'redirect' => ['route' => 'update', 'parameters' => ['context' => '\$context', 'id' => '\$id']],";
+        $lines[] = "            'route' => ['parameters' => ['context' => '\$context', 'id' => '\$id']],";
+        $lines[] = '        ],';
+        $lines[] = '    ],';
+        $lines[] = ')]';
+
+        return implode("\n", $lines);
     }
 }

--- a/src/Maker/InstallDefaultFiles.php
+++ b/src/Maker/InstallDefaultFiles.php
@@ -100,9 +100,67 @@ final class InstallDefaultFiles extends AbstractMaker
         //}
     }
 
+    private function attributesModeEnabled(): bool
+    {
+        return $this->parameterBag->has('sylius_easy_crud.attributes.enabled') &&
+            true === $this->parameterBag->get('sylius_easy_crud.attributes.enabled');
+    }
+
+    /**
+     * Build the AsAdmin attribute source code for a given resource scope.
+     */
+    private function buildAsAdminAttribute(string $aliasScope, array $options = []): string
+    {
+        $controller = $options['controller'] ?? null;
+        $templates = $options['templates'] ?? null;
+        $except = $options['except'] ?? null;
+        $breadcrumbTemplate = $options['breadcrumbTemplate'] ?? null;
+
+        $lines = ['#[AsAdmin('];
+        $lines[] = "    alias: 'sylius_happy_cms.{$aliasScope}',";
+        $lines[] = "    subheader: 'sylius_happy_cms.{$aliasScope}.admin.ui.subheader',";
+        $lines[] = "    breadcrumb: 'sylius_happy_cms.{$aliasScope}.admin.ui.index',";
+
+        if ($controller) {
+            $lines[] = "    controller: {$controller},";
+        }
+
+        if ($templates) {
+            $lines[] = "    templates: {$templates},";
+        }
+
+        if ($except) {
+            $lines[] = "    except: {$except},";
+        }
+
+        $lines[] = '    vars: [';
+        $lines[] = "        'index' => ['header' => 'sylius_happy_cms.{$aliasScope}.admin.ui.index'],";
+        $lines[] = "        'create' => ['header' => 'sylius_happy_cms.{$aliasScope}.admin.ui.create'],";
+
+        // The breadcrumb template is an "update" action template (mirrors generateRoute()'s
+        // templates['update']['breadcrumb']), not a "show" one.
+        $updateVars = "'header' => 'sylius_happy_cms.{$aliasScope}.admin.ui.update'";
+        if ($breadcrumbTemplate) {
+            // $breadcrumbTemplate is already a quoted PHP literal (like $controller/$templates).
+            $updateVars .= ", 'templates' => ['breadcrumb' => {$breadcrumbTemplate}]";
+        }
+        $lines[] = "        'update' => [{$updateVars}],";
+
+        $showVars = "'header' => 'sylius_happy_cms.{$aliasScope}.admin.ui.show'";
+        $showVars .= ", 'redirect' => ['route' => 'update', 'parameters' => ['context' => '\$context', 'id' => '\$id']]";
+        $showVars .= ", 'route' => ['parameters' => ['context' => '\$context', 'id' => '\$id']]";
+
+        $lines[] = "        'show' => [{$showVars}],";
+        $lines[] = '    ],';
+        $lines[] = ')]';
+
+        return implode("\n", $lines);
+    }
+
     private function generatePage(ConsoleStyle $io, Generator $generator): void
     {
         $scope = 'page';
+        $aliasScope = 'page';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'addRepo' => true, 'addTrans' => true, 'addContentBlocks' => true],
             ['prefix' => 'Entity', 'suffix' => 'Translation'],
@@ -110,13 +168,24 @@ final class InstallDefaultFiles extends AbstractMaker
             ['prefix' => 'Repository', 'suffix' => 'Repository'],
             ['prefix' => 'Admin', 'suffix' => 'Admin'],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute($scope, $io, [
-            'default' => '@SyliusHappyCMSPlugin\\\\page\\\\crud',
-        ]);
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope, [
+                'controller' => 'Adeliom\SyliusHappyCMSPlugin\Controller\Page\PageResourceController::class',
+                'templates' => "'@SyliusHappyCMSPlugin\\\\page\\\\crud'",
+            ]);
+        }
 
-        $this->generateSyliusResource($scope, $io);
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute($scope, $io, [
+                'default' => '@SyliusHappyCMSPlugin\\\\page\\\\crud',
+            ]);
+
+            $this->generateSyliusResource($scope, $io);
+        }
 
         $this->generateHappyCMSConfig($scope, $io);
     }
@@ -124,17 +193,25 @@ final class InstallDefaultFiles extends AbstractMaker
     private function generateConfig(ConsoleStyle $io, Generator $generator): void
     {
         $scope = 'config';
+        $aliasScope = 'config';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'addRepo' => true, 'addTrans' => true],
             ['prefix' => 'Entity', 'suffix' => 'Translation'],
             ['prefix' => 'Repository', 'suffix' => 'Repository'],
             ['prefix' => 'Admin', 'suffix' => 'Admin'],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute($scope, $io);
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope);
+        }
 
-        $this->generateSyliusResource($scope, $io);
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute($scope, $io);
+            $this->generateSyliusResource($scope, $io);
+        }
 
         $this->generateHappyCMSConfig($scope, $io);
     }
@@ -167,52 +244,82 @@ final class InstallDefaultFiles extends AbstractMaker
     private function generateMenu(ConsoleStyle $io, Generator $generator): void
     {
         $scope = 'menu';
+        $aliasScope = 'menu';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'entityName' => 'menu', 'addRepo' => true],
             ['prefix' => 'Repository', 'suffix' => 'Repository', 'entityName' => 'menu'],
             ['prefix' => 'Admin', 'suffix' => 'Admin', 'entityName' => 'menu'],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute($scope, $io);
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope);
+        }
 
-        $this->generateSyliusResource($scope, $io);
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute($scope, $io);
+            $this->generateSyliusResource($scope, $io);
+        }
 
         $this->generateHappyCMSConfig($scope, $io);
 
+        // Menu Item generation
         $entityName = 'menuItem';
+        $aliasScope = 'menu_item';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'entityName' => $entityName, 'addRepo' => true, 'addTrans' => true],
             ['prefix' => 'Entity', 'suffix' => 'Translation', 'entityName' => $entityName],
             ['prefix' => 'Repository', 'suffix' => 'Repository', 'entityName' => $entityName],
             ['prefix' => 'Admin', 'suffix' => 'Admin', 'entityName' => $entityName],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute($scope . '_item', $io, [
-            'default' => '@SyliusHappyCMSPlugin\\\\menu_item\\\\crud',
-            'update' => [
-                'form' => '@SyliusEasyCrudPlugin\\\\crud\\\\form\\\\_form.html.twig',
-                'breadcrumb' => '@SyliusHappyCMSPlugin\\\\menu_item\\\\crud\\\\_breadcrumb.html.twig',
-            ],
-            'create' => [],
-        ], $scope, "except: ['index']\n");
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope, [
+                'templates' => "'@SyliusHappyCMSPlugin\\\\menu_item\\\\crud'",
+                'except' => "['index']",
+                'breadcrumbTemplate' => "'@SyliusHappyCMSPlugin\\\\menu_item\\\\crud\\\\_breadcrumb.html.twig'",
+            ]);
+        }
+
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute($scope . '_item', $io, [
+                'default' => '@SyliusHappyCMSPlugin\\\\menu_item\\\\crud',
+                'update' => [
+                    'form' => '@SyliusEasyCrudPlugin\\\\crud\\\\form\\\\_form.html.twig',
+                    'breadcrumb' => '@SyliusHappyCMSPlugin\\\\menu_item\\\\crud\\\\_breadcrumb.html.twig',
+                ],
+                'create' => [],
+            ], $scope, "except: ['index']\n");
+        }
     }
 
     private function generateBlock(ConsoleStyle $io, Generator $generator): void
     {
         $scope = 'sharedBlock';
+        $aliasScope = 'shared_block';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'entityName' => 'sharedBlock', 'addRepo' => true, 'addTrans' => true],
             ['prefix' => 'Entity', 'suffix' => 'Translation', 'entityName' => 'sharedBlock'],
             ['prefix' => 'Repository', 'suffix' => 'Repository', 'entityName' => 'sharedBlock'],
             ['prefix' => 'Admin', 'suffix' => 'Admin', 'entityName' => 'sharedBlock'],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute('shared_block', $io);
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope);
+        }
 
-        $this->generateSyliusResource('shared_block', $io);
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute('shared_block', $io);
+            $this->generateSyliusResource('shared_block', $io);
+        }
 
         $this->generateHappyCMSConfig('shared_block', $io);
     }
@@ -220,16 +327,24 @@ final class InstallDefaultFiles extends AbstractMaker
     private function generateEntityRoute(ConsoleStyle $io, Generator $generator): void
     {
         $scope = 'Cmf';
+        $aliasScope = 'route';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'entityName' => 'route', 'addRepo' => true, 'addTrans' => false],
             ['prefix' => 'Repository', 'suffix' => 'Repository', 'entityName' => 'route'],
             ['prefix' => 'Admin', 'suffix' => 'Admin', 'entityName' => 'route'],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute(scope: 'route', io: $io, baseScope: 'Cmf');
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope);
+        }
 
-        $this->generateSyliusResource('route', $io);
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute(scope: 'route', io: $io, baseScope: 'Cmf');
+            $this->generateSyliusResource('route', $io);
+        }
 
         $this->generateHappyCMSConfig('route', $io);
     }
@@ -237,16 +352,24 @@ final class InstallDefaultFiles extends AbstractMaker
     private function generateRedirectRoute(ConsoleStyle $io, Generator $generator): void
     {
         $scope = 'Cmf';
+        $aliasScope = 'redirect_route';
         $files = [
             ['prefix' => 'Entity', 'suffix' => '', 'entityName' => 'redirectRoute', 'addRepo' => true, 'addTrans' => false],
             ['prefix' => 'Repository', 'suffix' => 'Repository', 'entityName' => 'redirectRoute'],
             ['prefix' => 'Admin', 'suffix' => 'Admin', 'entityName' => 'redirectRoute'],
         ];
-        $this->generateScope($scope, $files, $io, $generator);
 
-        $this->generateRoute(scope: 'redirect_route', io: $io, baseScope: 'Cmf');
+        $asAdminAttribute = null;
+        if ($this->attributesModeEnabled()) {
+            $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope);
+        }
 
-        $this->generateSyliusResource('redirect_route', $io);
+        $this->generateScope($scope, $files, $io, $generator, $asAdminAttribute);
+
+        if (!$this->attributesModeEnabled()) {
+            $this->generateRoute(scope: 'redirect_route', io: $io, baseScope: 'Cmf');
+            $this->generateSyliusResource('redirect_route', $io);
+        }
 
         $this->generateHappyCMSConfig('redirect_route', $io);
     }
@@ -254,7 +377,7 @@ final class InstallDefaultFiles extends AbstractMaker
     /**
      * @param array<int, array<string, bool|string>> $files
      */
-    private function generateScope(string $scope, array $files, ConsoleStyle $io, Generator $generator): void
+    private function generateScope(string $scope, array $files, ConsoleStyle $io, Generator $generator, ?string $asAdminAttribute = null): void
     {
         foreach ($files as $data) {
             $namespacePrefix = $data['prefix'] . '\HappyCMS\\' . ucfirst($scope);
@@ -277,17 +400,24 @@ final class InstallDefaultFiles extends AbstractMaker
                         ? $data['templateName']
                         : strtolower(is_string($data['prefix']) ? $data['prefix'] : '');
 
+                    $templateVariables = [
+                        'classNameDetail' => $classNameDetail,
+                        'scope' => ucfirst($scope),
+                        'addRepo' => $data['addRepo'] ?? false,
+                        'addTrans' => $data['addTrans'] ?? false,
+                        'addContentBlocks' => $data['addContentBlocks'] ?? false,
+                        'parentClassName' => $data['parentClassName'] ?? ucfirst($scope),
+                    ];
+
+                    // Add asAdminAttribute only for Admin classes when in attributes mode
+                    if ($asAdminAttribute && $data['prefix'] === 'Admin') {
+                        $templateVariables['asAdminAttribute'] = $asAdminAttribute;
+                    }
+
                     $generator->generateClass(
                         $classNameDetail->getFullName(),
                         __DIR__ . '/../Resources/skeleton/default/' . $templateName . '.tpl.php',
-                        [
-                            'classNameDetail' => $classNameDetail,
-                            'scope' => ucfirst($scope),
-                            'addRepo' => $data['addRepo'] ?? false,
-                            'addTrans' => $data['addTrans'] ?? false,
-                            'addContentBlocks' => $data['addContentBlocks'] ?? false,
-                            'parentClassName' => $data['parentClassName'] ?? ucfirst($scope),
-                        ],
+                        $templateVariables,
                     );
                     $generator->writeChanges();
                 }

--- a/src/Maker/InstallDefaultFiles.php
+++ b/src/Maker/InstallDefaultFiles.php
@@ -141,8 +141,9 @@ final class InstallDefaultFiles extends AbstractMaker
         // templates['update']['breadcrumb']), not a "show" one.
         $updateVars = "'header' => 'sylius_happy_cms.{$aliasScope}.admin.ui.update'";
         if ($breadcrumbTemplate) {
+            // Mirror the legacy YAML update.templates exactly (form + breadcrumb).
             // $breadcrumbTemplate is already a quoted PHP literal (like $controller/$templates).
-            $updateVars .= ", 'templates' => ['breadcrumb' => {$breadcrumbTemplate}]";
+            $updateVars .= ", 'templates' => ['form' => '@SyliusEasyCrudPlugin\\\\crud\\\\form\\\\_form.html.twig', 'breadcrumb' => {$breadcrumbTemplate}]";
         }
         $lines[] = "        'update' => [{$updateVars}],";
 
@@ -172,7 +173,7 @@ final class InstallDefaultFiles extends AbstractMaker
         $asAdminAttribute = null;
         if ($this->attributesModeEnabled()) {
             $asAdminAttribute = $this->buildAsAdminAttribute($aliasScope, [
-                'controller' => 'Adeliom\SyliusHappyCMSPlugin\Controller\Page\PageResourceController::class',
+                'controller' => '\Adeliom\SyliusHappyCMSPlugin\Controller\Page\PageResourceController::class',
                 'templates' => "'@SyliusHappyCMSPlugin\\\\page\\\\crud'",
             ]);
         }

--- a/src/Resources/skeleton/cms/admin.tpl.php
+++ b/src/Resources/skeleton/cms/admin.tpl.php
@@ -44,7 +44,13 @@ use Adeliom\SyliusEasyCrudPlugin\Enum\ColumnSizeEnum;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Validator\Constraints\Length;
+<?php if (isset($asAdminAttribute) && $asAdminAttribute) { ?>
+use Adeliom\SyliusEasyCrudPlugin\Metadata\AsAdmin;
+<?php } ?>
 
+<?php if (isset($asAdminAttribute) && $asAdminAttribute) { ?>
+<?= $asAdminAttribute ?>
+<?php } ?>
 final class <?= $classNameDetail->getShortName() ?>Admin extends AbstractAdmin implements ServiceSubscriberInterface
 {
     public static function getSubscribedServices(): array

--- a/src/Resources/skeleton/default/admin.tpl.php
+++ b/src/Resources/skeleton/default/admin.tpl.php
@@ -18,7 +18,13 @@ namespace <?= Str::getNamespace($classNameDetail->getFullName()) ?>;
 use <?= str_replace('Admin', 'Entity', Str::getNamespace($classNameDetail->getFullName())) ?>\<?= str_replace('Admin', '', $classNameDetail->getShortName()) ?>;
 use Adeliom\SyliusHappyCMSPlugin\Admin\<?= $scope ?>\<?= $classNameDetail->getShortName() ?> as Base<?=
     $classNameDetail->getShortName() ?>;
+<?php if (isset($asAdminAttribute) && $asAdminAttribute) { ?>
+use Adeliom\SyliusEasyCrudPlugin\Metadata\AsAdmin;
+<?php } ?>
 
+<?php if (isset($asAdminAttribute) && $asAdminAttribute) { ?>
+<?= $asAdminAttribute ?>
+<?php } ?>
 class <?= $classNameDetail->getShortName() ?> extends Base<?= $classNameDetail->getShortName() ?><?php echo "\n"; ?>{
 
     public static function getSubscribedServices(): array


### PR DESCRIPTION
## Contexte

easy-crud 2.1 introduit la déclaration de ressource par attribut `#[AsAdmin]` (sur la classe Admin), en remplacement des 2 blocs YAML legacy (`sylius_resource` + route `type: sylius.resource`). easy-crud reste **opt-in** via `sylius_easy_crud.attributes.enabled` (false par défaut).

Cette PR rend **HappyCMS compatible** : sa génération de code devient **dual-mode**, sans rien casser pour les projets existants.

## Comportement

`make:happy-cms:install` et `make:happy-cms:generate-cms-model` **lisent** le flag (jamais ne l'écrivent) :

| `attributes.enabled` | Génération |
|---|---|
| `false` / absent (défaut) | YAML — **inchangé** |
| `true` | classes Admin avec `#[AsAdmin]` complet, **pas** de YAML |

**XOR strict** (jamais les deux → pas de double déclaration). `media` / `media_folder` (sans admin) restent toujours en YAML.

Choix de conception : **alias explicite** dans `#[AsAdmin]` → pas de `#[AsResource]` sur les entités ni de `sylius_resource.mapping.paths` ; on garde `getName()`/`getEntityFqcn()` sur les Admin (le factory en déduit grid/model).

## Changements

- `src/Maker/InstallDefaultFiles.php` — détection du flag, `buildAsAdminAttribute()` par scope (alias, subheader/breadcrumb, controller Page, `vars` headers + redirect/route `$context`/`$id` sur update & show, `except`/templates menu_item), skip YAML en mode attribut.
- `src/Maker/CMS/MakeHappyCMS.php` — même branche pour `generate-cms-model`.
- `src/Resources/skeleton/{default,cms}/admin.tpl.php` — rendu conditionnel de `#[AsAdmin]`.
- `composer.json` — `agence-adeliom/sylius-easy-crud-plugin: ^2.1`.
- `docs/skills/happy-cms-migrate-to-attributes/SKILL.md` — skill guidant la migration d'un projet existant (table pré-remplie des 7 ressources, switch atomique, vérification).

## QA

- ECS : ✅
- PHPStan level max : ✅
- Rendu des attributs généré + `php -l` validés (`shared_block`, `page`, `menu_item`).

## À vérifier avant merge

- [ ] **Vérification runtime byte-identique** (`debug:router` avant/après) avec easy-crud 2.1 réellement installé — non faite ici car le vendor est en v2.0.9.
- [ ] **`MakeHappyCMS`** utilise un schéma d'alias `happy_cms_admin_{scope}` pour les CMS models custom — à revoir/aligner si besoin.
- [ ] `UPGRADE.md` à compléter (section passage en mode attribut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)